### PR TITLE
Auto-detect TOC heading selectors in tocbot

### DIFF
--- a/src/main/resources/docinfo/noorm-documentation/index-docinfo-footer.html
+++ b/src/main/resources/docinfo/noorm-documentation/index-docinfo-footer.html
@@ -20,14 +20,38 @@
 <script src="script/tocbot-3.0.2/tocbot.min.js"></script>
 <script>
     /* Tocbot dynamic TOC, works with tocbot 3.0.2 */
-    /* Source: https://github.com/asciidoctor/asciidoctor/issues/699#issuecomment-321066006 */
+    /* Source: https://github.com/asciidoctor/asciidoctor/issues/699#issuecomment-321066006
+     * Adapted to auto-detect the heading selector.
+     */
     var oldtoc = document.getElementById('toctitle').nextElementSibling;
+
+    var headingSelectorVal;
+    if (oldtoc.querySelector('.sectlevel5')) {
+        headingSelectorVal = 'h1, h2, h3, h4, h5, h6'
+    }
+    else if (oldtoc.querySelector('.sectlevel4')) {
+        headingSelectorVal = 'h1, h2, h3, h4, h5'
+    }
+    else if (oldtoc.querySelector('.sectlevel3')) {
+        headingSelectorVal = 'h1, h2, h3, h4'
+    }
+    else if (oldtoc.querySelector('.sectlevel2')) {
+        headingSelectorVal = 'h1, h2, h3'
+    }
+    else if (oldtoc.querySelector('.sectlevel1')) {
+        headingSelectorVal = 'h1, h2'
+    }
+    else {
+        // In case something went wrong
+        headingSelectorVal = 'h1, h2, h3, h4'
+    }
+
     var newtoc = document.createElement('div');
     newtoc.setAttribute('id', 'tocbot');
     newtoc.setAttribute('class', 'js-toc');
     oldtoc.parentNode.replaceChild(newtoc, oldtoc);
     tocbot.init({ contentSelector: '#content',
-        headingSelector: 'h1, h2, h3, h4',
+        headingSelector: headingSelectorVal,
         smoothScroll: false });
     var handleTocOnResize = function() {
         var width = window.innerWidth
@@ -35,7 +59,7 @@
                     || document.body.clientWidth;
         if (width < 768) {
             tocbot.refresh({ contentSelector: '#content',
-                headingSelector: 'h1, h2, h3, h4',
+                headingSelector: headingSelectorVal,
                 collapseDepth: 6,
                 activeLinkClass: 'ignoreactive',
                 throttleTimeout: 1000,
@@ -43,7 +67,7 @@
         }
         else {
             tocbot.refresh({ contentSelector: '#content',
-                headingSelector: 'h1, h2, h3, h4',
+                headingSelector: headingSelectorVal,
                 smoothScroll: false });
         }
     };

--- a/src/main/resources/docinfo/noorm-documentation/index-docinfo.html
+++ b/src/main/resources/docinfo/noorm-documentation/index-docinfo.html
@@ -22,6 +22,8 @@
   }
   @media print{
     #tocbot a.toc-link.node-name--H4{ display:none }
+    #tocbot a.toc-link.node-name--H5{ display:none }
+    #tocbot a.toc-link.node-name--H6{ display:none }
   }
 </style>
 <!-- /Dynamic TOC -->


### PR DESCRIPTION
So that `:toclevels:` is complied with.