### PR TITLE
Allow overriding meta attributes from the adoc file rather than from the maven

### DIFF
--- a/src/main/resources/docinfo/noorm-documentation/index-docinfo.html
+++ b/src/main/resources/docinfo/noorm-documentation/index-docinfo.html
@@ -1,7 +1,7 @@
 <!-- HibernateDoc.Meta -->
-<meta name="description" content="${html.meta.description}" />
-<meta name="keywords" content="${html.meta.keywords}" />
-<link rel="canonical" href="https://docs.jboss.org/hibernate/stable/${html.meta.project-key}/reference/en-US/html_single/" />
+<meta name="description" content="{html-meta-description}" />
+<meta name="keywords" content="{html-meta-keywords}" />
+<link rel="canonical" href="{html-meta-canonical-link}" />
 <!-- /HibernateDoc.Meta -->
 
 <link rel="stylesheet" href="css/hibernate.css" type="text/css" />


### PR DESCRIPTION
See https://docs.asciidoctor.org/asciidoc/latest/docinfo/

This would allow defining the attributes within the index.adoc as:
```adoc
:html-meta-description: Hibernate Search, full text search for your entities - Getting started with Hibernate Search’s Standalone POJO Mapper
:html-meta-keywords: hibernate, search, hibernate search, full text, lucene, elasticsearch
:html-meta-canonical-link: https://docs.jboss.org/hibernate/search/stable/getting-started/standalone/en-US/html_single/
```

Per each index output and there'd be no need to create multiple executions just to redefine the attributes. Also, the link currently strictly points to the refdoc 😔...   